### PR TITLE
PR add JWT token to project with simple authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@ DB_SERVER=localhost
 DB_NAME=StudentDB
 JWT__Issuer=https://studentapi.local
 JWT__Audience=https://studentapi.local
-JWT__Key=YourSuperSecretKey12345
+JWT__Key=YourSuperSecretKey12345ThisIsASufficientlyLongHS256SecretKey!!

--- a/src/Controllers/AuthController.cs
+++ b/src/Controllers/AuthController.cs
@@ -1,0 +1,69 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace StudentAPI.Controllers;
+
+[ApiController]
+[Route("auth")]
+public class AuthController : ControllerBase
+{
+    private readonly IConfiguration _config;
+
+    public AuthController(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public record LoginRequest(string Username, string Password);
+    public record TokenResponse(string Token, DateTime ExpiresAtUtc);
+
+    [AllowAnonymous]
+    [HttpPost("token")]
+    public IActionResult CreateToken([FromBody] LoginRequest request)
+    {
+        // Demo-only: accept any non-empty username/password. Replace with real validation.
+        if (string.IsNullOrWhiteSpace(request.Username) || string.IsNullOrWhiteSpace(request.Password))
+        {
+            return BadRequest("Username and password are required.");
+        }
+
+        var issuer = _config["JWT:Issuer"] ?? Environment.GetEnvironmentVariable("JWT__Issuer");
+        var audience = _config["JWT:Audience"] ?? Environment.GetEnvironmentVariable("JWT__Audience");
+        var key = _config["JWT:Key"] ?? Environment.GetEnvironmentVariable("JWT__Key");
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return StatusCode(500, "JWT key is not configured.");
+        }
+
+        var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key));
+        var creds = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
+
+        var now = DateTime.UtcNow;
+        var expires = now.AddHours(1);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, request.Username),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new(ClaimTypes.Name, request.Username)
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: issuer,
+            audience: audience,
+            claims: claims,
+            notBefore: now.AddMinutes(-1),
+            expires: expires,
+            signingCredentials: creds
+        );
+
+        var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
+        return Ok(new TokenResponse(tokenString, expires));
+    }
+}
+

--- a/src/Controllers/AuthTestController.cs
+++ b/src/Controllers/AuthTestController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace StudentAPI.Controllers;
+
+[ApiController]
+[Route("auth-test")]
+public class AuthTestController : ControllerBase
+{
+    [Authorize]
+    [HttpGet("ping")]
+    public IActionResult Ping()
+    {
+        return Ok(new { ok = true });
+    }
+}
+

--- a/src/StudentAPI.csproj
+++ b/src/StudentAPI.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,7 @@
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <ASPNETCORE_ENVIRONMENT>Test</ASPNETCORE_ENVIRONMENT>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/tests/StudentAPI.Tests/JwtAuthTests.cs
+++ b/tests/StudentAPI.Tests/JwtAuthTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using StudentAPI.Data;
+using Xunit;
+
+namespace StudentAPI.Tests;
+
+public class JwtAuthTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private const string Issuer = "https://studentapi.local";
+    private const string Audience = "https://studentapi.local";
+    // Use >= 32 bytes key for HS256
+    private const string Key = "ThisIsASufficientlyLongHS256SecretKey!!";
+
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public JwtAuthTests(WebApplicationFactory<Program> factory)
+    {
+        // Ensure JWT env vars are available to Program
+        Environment.SetEnvironmentVariable("JWT__Issuer", Issuer);
+        Environment.SetEnvironmentVariable("JWT__Audience", Audience);
+        Environment.SetEnvironmentVariable("JWT__Key", Key);
+
+        // Provide dummy DB envs (won't be used after override)
+        Environment.SetEnvironmentVariable("DB_SERVER", "localhost");
+        Environment.SetEnvironmentVariable("DB_NAME", "StudentDB");
+        Environment.SetEnvironmentVariable("DB_USER", "sa");
+        Environment.SetEnvironmentVariable("DB_PASSWORD", "YourStrong!Passw0rd");
+
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                // Replace SQL Server ApplicationDbContext with InMemory DB
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null)
+                {
+                    services.Remove(descriptor);
+                }
+
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase("JwtAuthTests"));
+            });
+        });
+    }
+
+    private static string CreateJwt()
+    {
+        var credentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Key)), SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: Issuer,
+            audience: Audience,
+            claims: new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, "test-user"),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            },
+            notBefore: DateTime.UtcNow.AddMinutes(-1),
+            expires: DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: credentials
+        );
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    [Fact]
+    public async Task Without_Token_Returns_401()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/auth-test/ping");
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task With_Valid_Token_Returns_200()
+    {
+        var client = _factory.CreateClient();
+        var token = CreateJwt();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var resp = await client.GetAsync("/auth-test/ping");
+
+        // Authorized should pass and controller returns OK
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().NotBeNull();
+    }
+}

--- a/tests/StudentAPI.Tests/JwtAuthTests.cs
+++ b/tests/StudentAPI.Tests/JwtAuthTests.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
@@ -96,4 +99,18 @@ public class JwtAuthTests : IClassFixture<WebApplicationFactory<Program>>
         var body = await resp.Content.ReadAsStringAsync();
         body.Should().NotBeNull();
     }
+
+    [Fact]
+    public async Task With_Valid_Token_Can_Create_Simple_Token()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.PostAsync("/auth/token", new StringContent("{\"username\":\"user1\",\"password\":\"pass1\"}", Encoding.UTF8, "application/json"));
+        Console.WriteLine(resp);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var obj = await resp.Content.ReadFromJsonAsync<Dictionary<string, object>>();
+        var token = obj?["token"]; 
+        token.Should().NotBeNull();
+    }
+        
 }

--- a/tests/StudentAPI.Tests/StudentAPI.Tests.csproj
+++ b/tests/StudentAPI.Tests/StudentAPI.Tests.csproj
@@ -9,7 +9,9 @@
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.8" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Added
 - InMemory for testing in the main project.
 - test.runsettings to define test environment.
 - Auth controller and Auth Test to check the JWT token is working.
 - simple AuthController for visualizing the working flow.

Updated
 - InMemory from 9.0.8 to 9.0.9 in test project.
 - JWT_Key example for .env.example file.
 - program.cs file to align with the test project, clean warnings and errors when running dotnet test.
